### PR TITLE
Support for TEXS0001 and mipmaps with rotated frames

### DIFF
--- a/RePKG.Application/Texture/TexFrameInfoContainerReader.cs
+++ b/RePKG.Application/Texture/TexFrameInfoContainerReader.cs
@@ -23,6 +23,7 @@ namespace RePKG.Application.Texture
 
             switch (container.Magic)
             {
+                case "TEXS0001":
                 case "TEXS0002":
                     break;
 
@@ -35,22 +36,48 @@ namespace RePKG.Application.Texture
                     throw new UnknownMagicException(nameof(TexFrameInfoContainerReader), container.Magic);
             }
 
-            for (var i = 0; i < frameCount; i++)
+            switch (container.Magic)
             {
-                container.Frames.Add(new TexFrameInfo
-                {
-                    ImageId = reader.ReadInt32(),
-                    Frametime = reader.ReadSingle(),
-                    X = reader.ReadSingle(),
-                    Y = reader.ReadSingle(),
-                    Width = reader.ReadSingle(),
-                    Unk0 = reader.ReadSingle(),
-                    Unk1 = reader.ReadSingle(),
-                    Height = reader.ReadSingle(),
-                });
+                case "TEXS0001":
+                    for (var i = 0; i < frameCount; i++)
+                    {
+                        container.Frames.Add(new TexFrameInfo
+                        {
+                            ImageId = reader.ReadInt32(),
+                            Frametime = reader.ReadSingle(),
+                            X = reader.ReadInt32(),
+                            Y = reader.ReadInt32(),
+                            Width = reader.ReadInt32(),
+                            WidthY = reader.ReadInt32(),
+                            HeightX = reader.ReadInt32(),
+                            Height = reader.ReadInt32(),
+                        });
+                    }
+                    break;
+                
+                case "TEXS0002":
+                case "TEXS0003":
+                    for (var i = 0; i < frameCount; i++)
+                    {
+                        container.Frames.Add(new TexFrameInfo
+                        {
+                            ImageId = reader.ReadInt32(),
+                            Frametime = reader.ReadSingle(),
+                            X = reader.ReadSingle(),
+                            Y = reader.ReadSingle(),
+                            Width = reader.ReadSingle(),
+                            WidthY = reader.ReadSingle(),
+                            HeightX = reader.ReadSingle(),
+                            Height = reader.ReadSingle(),
+                        });
+                    }
+                    break;
+                    
+                default:
+                    throw new UnknownMagicException(nameof(TexFrameInfoContainerReader), container.Magic);
             }
 
-            // TEXS0002 doesn't save gif width/height so we will get it from first frame
+            // TEXS0001 and TEXS0002 don't save gif width/height so we will get it from first frame
             // Because we use those values in TexToImageConverter
             if (container.GifWidth == 0 ||
                 container.GifHeight == 0)

--- a/RePKG.Application/Texture/TexToImageConverter.cs
+++ b/RePKG.Application/Texture/TexToImageConverter.cs
@@ -89,14 +89,24 @@ namespace RePKG.Application.Texture
 
             foreach (var frameInfo in tex.FrameInfoContainer.Frames)
             {
+                // Frames can be turned to fit into the map so we need to compute cropping coordinates first
+                // We're keeping width and height signed for the rotation angle calculation
+                var width = frameInfo.Width != 0 ? frameInfo.Width : frameInfo.HeightX;
+                var height = frameInfo.Height != 0 ? frameInfo.Height : frameInfo.WidthY;
+                var x = Math.Min(frameInfo.X, frameInfo.X + width);
+                var y = Math.Min(frameInfo.Y, frameInfo.Y + height);
+                
+                // This formula gives us the angle for which we need to turn the frame,
+                // assuming that either Width or HeightX is 0 (same with Height and WidthY)
+                var rotationAngle = -(Math.Atan2(Math.Sign(height), Math.Sign(width)) - Math.PI / 4);
+                
                 var frame = sequenceImages[frameInfo.ImageId].Clone(
                     context => context.Crop(new Rectangle(
-                        (int) frameInfo.X,
-                        (int) frameInfo.Y,
-                        (int) frameInfo.Width,
-                        (int) frameInfo.Height)
-                    )
-                );
+                        (int) x,
+                        (int) y,
+                        (int) Math.Abs(width),
+                        (int) Math.Abs(height))
+                    ).Rotate((float) Math.Round(rotationAngle * 180 / Math.PI)));
 
                 var metadata = frame.Frames.RootFrame.Metadata.GetFormatMetadata(GifFormat.Instance);
                 metadata.FrameDelay = (int) Math.Round(frameInfo.Frametime * 100.0f);

--- a/RePKG.Application/Texture/Writer/TexFrameInfoContainerWriter.cs
+++ b/RePKG.Application/Texture/Writer/TexFrameInfoContainerWriter.cs
@@ -52,8 +52,8 @@ namespace RePKG.Application.Texture
                 writer.Write(frame.X);
                 writer.Write(frame.Y);
                 writer.Write(frame.Width);
-                writer.Write(frame.Unk0);
-                writer.Write(frame.Unk1);
+                writer.Write(frame.WidthY);
+                writer.Write(frame.HeightX);
                 writer.Write(frame.Height);
             }
         }

--- a/RePKG.Core/Texture/Interfaces/Data/ITexFrameInfo.cs
+++ b/RePKG.Core/Texture/Interfaces/Data/ITexFrameInfo.cs
@@ -7,8 +7,8 @@ namespace RePKG.Core.Texture
         float X { get; set; }
         float Y { get; set; }
         float Width { get; set; }
-        float Unk0 { get; set; }
-        float Unk1 { get; set; }
+        float WidthY { get; set; }
+        float HeightX { get; set; }
         float Height { get; set; }
     }
 }

--- a/RePKG.Core/Texture/TexFrameInfo.cs
+++ b/RePKG.Core/Texture/TexFrameInfo.cs
@@ -7,8 +7,8 @@ namespace RePKG.Core.Texture
         public float X { get; set; }
         public float Y { get; set; }
         public float Width { get; set; }
-        public float Unk0 { get; set; }
-        public float Unk1 { get; set; }
+        public float WidthY { get; set; }
+        public float HeightX { get; set; }
         public float Height { get; set; }
     }
 }

--- a/RePKG.Native/Texture/CTexFrameInfo.cs
+++ b/RePKG.Native/Texture/CTexFrameInfo.cs
@@ -55,13 +55,13 @@ namespace RePKG.Native.Texture
             set => Self->width = value;
         }
 
-        public float Unk0
+        public float WidthY
         {
             get => Self->unk0;
             set => Self->unk0 = value;
         }
 
-        public float Unk1
+        public float HeightX
         {
             get => Self->unk1;
             set => Self->unk1 = value;

--- a/RePKG.Native/Texture/TexConverter.cs
+++ b/RePKG.Native/Texture/TexConverter.cs
@@ -128,8 +128,8 @@ namespace RePKG.Native.Texture
             dst->x = src.X;
             dst->y = src.Y;
             dst->width = src.Width;
-            dst->unk0 = src.Unk0;
-            dst->unk1 = src.Unk1;
+            dst->unk0 = src.WidthY;
+            dst->unk1 = src.HeightX;
             dst->height = src.Height;
         }
     }


### PR DESCRIPTION
Support for `TEXS0001` headers ported from [Wallpaper Engine plugin for KDE](https://github.com/catsout/wallpaper-engine-kde-plugin). Basically the same as `TEXS0002`, except using `Int32` in most places.

**More on the rotated frames:**
When unpacking a wallpaper, I found a texture file that had the two "unknown" variables used for the last 4 frames.
Upon closer inspection, it turned out those variables are used to denote the height and width of the mipmap part used for the frame if (and only if) the frame is rotated in the mipmap.
Namely, `Unk0` is the distance on the **Y** axis corresponding to the **width** of the original frame (hence `WidthY`), and `Unk1` is the distance on the **X** axis corresponding to the **height** of the original frame (hence `HeightX`). Both have signs corresponding to the relative direction of the frame (`WidthY` being negative and `HeightX` being positive means that the frame is drawn _bottom-to-top_ and _left-to-right_, respectively).
Attached is the texture file (packed to .zip because GitHub does not allow .tex files) and the corresponding mipmap.
 
[11999c71119c2b1495b54f6c2cf75d18.zip](https://github.com/notscuffed/repkg/files/7090683/11999c71119c2b1495b54f6c2cf75d18.zip)
[11999c71119c2b1495b54f6c2cf75d18.png](https://user-images.githubusercontent.com/24571282/131663712-d770701a-321f-42fa-9ced-763e146bcaa2.png)
