### PR TITLE
fix: remove redundant mipmap filesize limits

### DIFF
--- a/RePKG.Application/Constants.cs
+++ b/RePKG.Application/Constants.cs
@@ -5,6 +5,5 @@ namespace RePKG.Application
         public const int MaximumFrameCount = 100_000;
         public const int MaximumImageCount = 100;
         public const int MaximumMipmapCount = 32;
-        public const int MaximumMipmapByteCount = 250_000_000; // 250 MB
     }
 }

--- a/RePKG.Application/Texture/TexImageReader.cs
+++ b/RePKG.Application/Texture/TexImageReader.cs
@@ -111,10 +111,6 @@ namespace RePKG.Application.Texture
             if (reader.BaseStream.Position + byteCount > reader.BaseStream.Length)
                 throw new UnsafeTexException("Detected invalid mipmap byte count - exceeds stream length");
 
-            if (byteCount > Constants.MaximumMipmapByteCount)
-                throw new UnsafeTexException(
-                    $"Mipmap byte count exceeds maximum size: {byteCount}/{Constants.MaximumMipmapByteCount}");
-
             if (!ReadMipmapBytes)
             {
                 reader.BaseStream.Seek(byteCount, SeekOrigin.Current);


### PR DESCRIPTION
There is an unexplained limit to mipmaps, seemingly a sanity check?

removing it instead of having an arbitrary limit and prevent files from being extracted despite being valid