### PR TITLE
feat: add pack command, video TEX support, .mpkg support, and bugfixes

### DIFF
--- a/RePKG.Application/Extensions.cs
+++ b/RePKG.Application/Extensions.cs
@@ -53,8 +53,9 @@ namespace RePKG.Application
             if (writer == null) throw new ArgumentNullException(nameof(writer));
             if (input == null) throw new ArgumentNullException(nameof(input));
 
-            writer.Write(input.Length);
-            writer.Write(Encoding.UTF8.GetBytes(input));
+            var bytes = Encoding.UTF8.GetBytes(input);
+            writer.Write(bytes.Length);
+            writer.Write(bytes);
         }
     }
 }

--- a/RePKG.Application/Texture/Helpers/ImageToTexConverter.cs
+++ b/RePKG.Application/Texture/Helpers/ImageToTexConverter.cs
@@ -1,0 +1,340 @@
+using System;
+using System.IO;
+using RePKG.Core.Texture;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace RePKG.Application.Texture.Helpers
+{
+    public static class ImageToTexConverter
+    {
+        public static Tex Convert(string imagePath, TexFormat format = TexFormat.RGBA8888, bool lz4 = false)
+        {
+            using (var image = Image.Load<Rgba32>(imagePath))
+            {
+                return Convert(image, format, lz4);
+            }
+        }
+
+        public static Tex Convert(Image<Rgba32> image, TexFormat format = TexFormat.RGBA8888, bool lz4 = false)
+        {
+            var texWidth = NextPowerOfTwo(image.Width);
+            var texHeight = NextPowerOfTwo(image.Height);
+
+            if (image.Width != texWidth || image.Height != texHeight)
+                image.Mutate(x => x.Resize(texWidth, texHeight));
+
+            var pixels = new Rgba32[texWidth * texHeight];
+            image.CopyPixelDataTo(pixels);
+
+            byte[] pixelData;
+            var mipmapFormat = GetPixelData(pixels, texWidth, texHeight, format, out pixelData);
+
+            var mipmap = new TexMipmap
+            {
+                Width = texWidth,
+                Height = texHeight,
+                Bytes = pixelData,
+                Format = mipmapFormat,
+                IsLZ4Compressed = false,
+                DecompressedBytesCount = pixelData.Length
+            };
+
+            var texImage = new TexImage();
+            texImage.Mipmaps.Add(mipmap);
+
+            var imageContainer = new TexImageContainer
+            {
+                Magic = "TEXB0002",
+                ImageContainerVersion = TexImageContainerVersion.Version2,
+                ImageFormat = FreeImageFormat.FIF_UNKNOWN
+            };
+            imageContainer.Images.Add(texImage);
+
+            var header = new TexHeader
+            {
+                Format = format,
+                Flags = TexFlags.None,
+                TextureWidth = texWidth,
+                TextureHeight = texHeight,
+                ImageWidth = image.Width,
+                ImageHeight = image.Height,
+                UnkInt0 = 0
+            };
+
+            var tex = new Tex
+            {
+                Magic1 = "TEXV0005",
+                Magic2 = "TEXI0001",
+                Header = header,
+                ImagesContainer = imageContainer
+            };
+
+            if (lz4)
+            {
+                var compressor = new TexMipmapCompressor();
+                compressor.CompressMipmap(mipmap, mipmapFormat, true);
+            }
+
+            return tex;
+        }
+
+        public static Tex ConvertFromGif(string gifPath, bool lz4 = false)
+        {
+            using (var gif = Image.Load<Rgba32>(gifPath))
+            {
+                var frames = gif.Frames.Count;
+                if (frames == 0)
+                    return Convert(gif, TexFormat.RGBA8888, lz4);
+
+                var texWidth = NextPowerOfTwo(gif.Width);
+                var texHeight = NextPowerOfTwo(gif.Height);
+
+                var header = new TexHeader
+                {
+                    Format = TexFormat.RGBA8888,
+                    Flags = TexFlags.IsGif,
+                    TextureWidth = texWidth,
+                    TextureHeight = texHeight,
+                    ImageWidth = gif.Width,
+                    ImageHeight = gif.Height,
+                    UnkInt0 = 0
+                };
+
+                var imageContainer = new TexImageContainer
+                {
+                    Magic = "TEXB0003",
+                    ImageContainerVersion = TexImageContainerVersion.Version3,
+                    ImageFormat = FreeImageFormat.FIF_GIF
+                };
+
+                var frameInfos = new TexFrameInfoContainer
+                {
+                    Magic = "TEXS0003",
+                    GifWidth = gif.Width,
+                    GifHeight = gif.Height
+                };
+
+                for (int i = 0; i < frames; i++)
+                {
+                    using (var frame = gif.Frames.CloneFrame(i))
+                    {
+                        if (frame.Width != texWidth || frame.Height != texHeight)
+                            frame.Mutate(x => x.Resize(texWidth, texHeight));
+
+                        var pixels = new Rgba32[texWidth * texHeight];
+                        frame.CopyPixelDataTo(pixels);
+                        var pixelData = PixelDataFromRgba32(pixels, texWidth, texHeight);
+
+                        var mipmap = new TexMipmap
+                        {
+                            Width = texWidth,
+                            Height = texHeight,
+                            Bytes = pixelData,
+                            Format = MipmapFormat.RGBA8888,
+                            IsLZ4Compressed = false,
+                            DecompressedBytesCount = pixelData.Length
+                        };
+
+                        if (lz4)
+                        {
+                            var compressor = new TexMipmapCompressor();
+                            compressor.CompressMipmap(mipmap, MipmapFormat.RGBA8888, true);
+                        }
+
+                        var texImage = new TexImage();
+                        texImage.Mipmaps.Add(mipmap);
+                        imageContainer.Images.Add(texImage);
+
+                        var delay = gif.Frames[i].Metadata.GetFormatMetadata(SixLabors.ImageSharp.Formats.Gif.GifFormat.Instance).FrameDelay;
+                        frameInfos.Frames.Add(new TexFrameInfo
+                        {
+                            ImageId = i,
+                            Frametime = delay / 100f,
+                            X = 0,
+                            Y = 0,
+                            Width = gif.Width,
+                            Height = gif.Height,
+                            WidthY = gif.Width,
+                            HeightX = gif.Height
+                        });
+                    }
+                }
+
+                var tex = new Tex
+                {
+                    Magic1 = "TEXV0005",
+                    Magic2 = "TEXI0001",
+                    Header = header,
+                    ImagesContainer = imageContainer,
+                    FrameInfoContainer = frameInfos
+                };
+
+                return tex;
+            }
+        }
+
+        private static MipmapFormat GetPixelData(Rgba32[] pixels, int width, int height, TexFormat format, out byte[] pixelData)
+        {
+            switch (format)
+            {
+                case TexFormat.RGBA8888:
+                    pixelData = PixelDataFromRgba32(pixels, width, height);
+                    return MipmapFormat.RGBA8888;
+
+                case TexFormat.R8:
+                    pixelData = new byte[width * height];
+                    for (int i = 0; i < width * height; i++)
+                        pixelData[i] = (byte)((pixels[i].R * 299 + pixels[i].G * 587 + pixels[i].B * 114) / 1000);
+                    return MipmapFormat.R8;
+
+                case TexFormat.RG88:
+                    pixelData = new byte[width * height * 2];
+                    for (int i = 0; i < width * height; i++)
+                    {
+                        pixelData[i * 2] = pixels[i].R;
+                        pixelData[i * 2 + 1] = pixels[i].G;
+                    }
+                    return MipmapFormat.RG88;
+
+                default:
+                    throw new NotSupportedException($"TexFormat {format} not supported");
+            }
+        }
+
+        private static byte[] PixelDataFromRgba32(Rgba32[] pixels, int width, int height)
+        {
+            var data = new byte[width * height * 4];
+            for (int i = 0; i < width * height; i++)
+            {
+                data[i * 4] = pixels[i].R;
+                data[i * 4 + 1] = pixels[i].G;
+                data[i * 4 + 2] = pixels[i].B;
+                data[i * 4 + 3] = pixels[i].A;
+            }
+            return data;
+        }
+
+        public static Tex ConvertFromVideo(string videoPath, int width = 0, int height = 0, bool lz4 = false)
+        {
+            var videoBytes = File.ReadAllBytes(videoPath);
+
+            if (width <= 0 || height <= 0)
+                ProbeVideoDimensions(videoPath, ref width, ref height);
+
+            if (width <= 0) width = 1920;
+            if (height <= 0) height = 1080;
+
+            var texWidth = NextPowerOfTwo(width);
+            var texHeight = NextPowerOfTwo(height);
+
+            var mipmap = new TexMipmap
+            {
+                Width = texWidth,
+                Height = texHeight,
+                Bytes = videoBytes,
+                Format = MipmapFormat.VideoMp4,
+                IsLZ4Compressed = false,
+                DecompressedBytesCount = videoBytes.Length
+            };
+
+            var texImage = new TexImage();
+            texImage.Mipmaps.Add(mipmap);
+
+            var imageContainer = new TexImageContainer
+            {
+                Magic = "TEXB0004",
+                ImageContainerVersion = TexImageContainerVersion.Version4,
+                ImageFormat = FreeImageFormat.FIF_UNKNOWN
+            };
+            imageContainer.Images.Add(texImage);
+
+            var header = new TexHeader
+            {
+                Format = TexFormat.RGBA8888,
+                Flags = TexFlags.IsVideoTexture,
+                TextureWidth = texWidth,
+                TextureHeight = texHeight,
+                ImageWidth = width,
+                ImageHeight = height,
+                UnkInt0 = 0
+            };
+
+            var tex = new Tex
+            {
+                Magic1 = "TEXV0005",
+                Magic2 = "TEXI0001",
+                Header = header,
+                ImagesContainer = imageContainer
+            };
+
+            return tex;
+        }
+
+        private static void ProbeVideoDimensions(string videoPath, ref int width, ref int height)
+        {
+            try
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo("ffprobe")
+                {
+                    Arguments = $"-v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0 \"{videoPath}\"",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using (var proc = System.Diagnostics.Process.Start(psi))
+                {
+                    if (proc != null)
+                    {
+                        var output = proc.StandardOutput.ReadToEnd().Trim();
+                        proc.WaitForExit(3000);
+                        if (proc.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                        {
+                            var parts = output.Split(',');
+                            if (parts.Length == 2)
+                            {
+                                int.TryParse(parts[0], out width);
+                                int.TryParse(parts[1], out height);
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // ffprobe not available, user-provided or default dimensions used
+            }
+        }
+
+        public static bool IsVideoFile(string path)
+        {
+            var ext = Path.GetExtension(path)?.ToLowerInvariant();
+            switch (ext)
+            {
+                case ".mp4":
+                case ".webm":
+                case ".avi":
+                case ".mov":
+                case ".mkv":
+                case ".flv":
+                case ".wmv":
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static int NextPowerOfTwo(int n)
+        {
+            if (n <= 0) return 1;
+            n--;
+            n |= n >> 1;
+            n |= n >> 2;
+            n |= n >> 4;
+            n |= n >> 8;
+            n |= n >> 16;
+            return n + 1;
+        }
+    }
+}

--- a/RePKG.Application/Texture/TexToImageConverter.cs
+++ b/RePKG.Application/Texture/TexToImageConverter.cs
@@ -53,9 +53,12 @@ namespace RePKG.Application.Texture
             {
                 var image = ImageFromRawFormat(format, sourceMipmap.Bytes, sourceMipmap.Width, sourceMipmap.Height);
 
-                if (sourceMipmap.Width != tex.Header.ImageWidth ||
-                    sourceMipmap.Height != tex.Header.ImageHeight)
+                if (sourceMipmap.Width > tex.Header.ImageWidth ||
+                    sourceMipmap.Height > tex.Header.ImageHeight)
                     image.Mutate(x => x.Crop(tex.Header.ImageWidth, tex.Header.ImageHeight));
+                else if (sourceMipmap.Width < tex.Header.ImageWidth ||
+                    sourceMipmap.Height < tex.Header.ImageHeight)
+                    image.Mutate(x => x.Resize(tex.Header.ImageWidth, tex.Header.ImageHeight));
 
                 using (var memoryStream = new MemoryStream())
                 {

--- a/RePKG.Application/Texture/Writer/TexImageContainerWriter.cs
+++ b/RePKG.Application/Texture/Writer/TexImageContainerWriter.cs
@@ -32,13 +32,18 @@ namespace RePKG.Application.Texture
                     writer.Write((int) imageContainer.ImageFormat);
                     break;
 
+                case TexImageContainerVersion.Version4:
+                    writer.Write((int) imageContainer.ImageFormat);
+                    writer.Write(imageContainer.ImageFormat == FreeImageFormat.FIF_MP4 ? 1 : 0);
+                    break;
+
                 default:
                     throw new UnknownMagicException(nameof(TexImageContainerWriter), imageContainer.Magic);
             }
             
             foreach (var image in imageContainer.Images)
             {
-                _texImageWriter.WriteTo(writer, imageContainer.ImageContainerVersion, image);
+                _texImageWriter.WriteTo(writer, imageContainer.ImageContainerVersion, imageContainer.ImageFormat, image);
             }
         }
     }

--- a/RePKG.Application/Texture/Writer/TexImageWriter.cs
+++ b/RePKG.Application/Texture/Writer/TexImageWriter.cs
@@ -6,12 +6,12 @@ namespace RePKG.Application.Texture
 {
     public class TexImageWriter : ITexImageWriter
     {
-        public void WriteTo(BinaryWriter writer, TexImageContainerVersion containerVersion, ITexImage image)
+        public void WriteTo(BinaryWriter writer, TexImageContainerVersion containerVersion, FreeImageFormat format, ITexImage image)
         {
             if (writer == null) throw new ArgumentNullException(nameof(writer));
             if (image == null) throw new ArgumentNullException(nameof(image));
 
-            var mipmapWriter = PickMipmapWriter(containerVersion);
+            var mipmapWriter = PickMipmapWriter(containerVersion, format);
 
             writer.Write(image.Mipmaps.Count);
 
@@ -53,7 +53,26 @@ namespace RePKG.Application.Texture
             }
         }
 
-        private static Action<BinaryWriter, ITexMipmap> PickMipmapWriter(TexImageContainerVersion containerVersion)
+        private static void WriteMipmapV4(BinaryWriter writer, ITexMipmap mipmap)
+        {
+            writer.Write(1); // param1
+            writer.Write(2); // param2
+            writer.WriteNString(""); // conditionJson (empty)
+            writer.Write(1); // param3
+            writer.Write(mipmap.Width);
+            writer.Write(mipmap.Height);
+            writer.Write(mipmap.IsLZ4Compressed ? 1 : 0);
+            writer.Write(mipmap.DecompressedBytesCount);
+
+            using (var stream = mipmap.GetBytesStream())
+            {
+                writer.Write((int) stream.Length);
+                writer.Flush();
+                stream.CopyTo(writer.BaseStream);
+            }
+        }
+
+        private static Action<BinaryWriter, ITexMipmap> PickMipmapWriter(TexImageContainerVersion containerVersion, FreeImageFormat format)
         {
             switch (containerVersion)
             {
@@ -62,6 +81,11 @@ namespace RePKG.Application.Texture
 
                 case TexImageContainerVersion.Version2:
                 case TexImageContainerVersion.Version3:
+                    return WriteMipmapV2And3;
+
+                case TexImageContainerVersion.Version4:
+                    if (format == FreeImageFormat.FIF_MP4)
+                        return WriteMipmapV4;
                     return WriteMipmapV2And3;
 
                 default:

--- a/RePKG.Core/Texture/Interfaces/Writer/ITexImageWriter.cs
+++ b/RePKG.Core/Texture/Interfaces/Writer/ITexImageWriter.cs
@@ -4,6 +4,6 @@ namespace RePKG.Core.Texture
 {
     public interface ITexImageWriter
     {
-        void WriteTo(BinaryWriter writer, TexImageContainerVersion containerVersion, ITexImage image);
+        void WriteTo(BinaryWriter writer, TexImageContainerVersion containerVersion, FreeImageFormat format, ITexImage image);
     }
 }

--- a/RePKG/Command/Extract.cs
+++ b/RePKG/Command/Extract.cs
@@ -130,7 +130,8 @@ namespace RePKG.Command
 
             if (_options.Recursive)
             {
-                foreach (var file in directoryInfo.EnumerateFiles("*.pkg", SearchOption.AllDirectories))
+                foreach (var file in directoryInfo.EnumerateFiles("*.pkg", SearchOption.AllDirectories)
+                    .Concat(directoryInfo.EnumerateFiles("*.mpkg", SearchOption.AllDirectories)))
                 {
                     if (file.Directory == null || file.Directory.FullName.Length < rootDirectoryLength)
                         ExtractPkg(file);
@@ -143,7 +144,8 @@ namespace RePKG.Command
 
             foreach (var directory in directoryInfo.EnumerateDirectories())
             {
-                foreach (var file in directory.EnumerateFiles("*.pkg"))
+                foreach (var file in directory.EnumerateFiles("*.pkg")
+                    .Concat(directory.EnumerateFiles("*.mpkg")))
                 {
                     ExtractPkg(file, true, directory.FullName.Substring(rootDirectoryLength));
                 }
@@ -154,7 +156,8 @@ namespace RePKG.Command
         {
             Directory.CreateDirectory(_options.OutputDirectory);
 
-            if (fileInfo.Extension.Equals(".pkg", StringComparison.OrdinalIgnoreCase))
+            if (fileInfo.Extension.Equals(".pkg", StringComparison.OrdinalIgnoreCase) || 
+                fileInfo.Extension.Equals(".mpkg", StringComparison.OrdinalIgnoreCase))
                 ExtractPkg(fileInfo);
             else if (fileInfo.Extension.Equals(".tex", StringComparison.OrdinalIgnoreCase))
             {

--- a/RePKG/Command/Info.cs
+++ b/RePKG/Command/Info.cs
@@ -62,7 +62,8 @@ namespace RePKG.Command
 
             foreach (var directory in directoryInfo.EnumerateDirectories())
             {
-                foreach (var file in directory.EnumerateFiles("*.pkg"))
+                foreach (var file in directory.EnumerateFiles("*.pkg")
+                    .Concat(directory.EnumerateFiles("*.mpkg")))
                 {
                     InfoPkg(file, file.FullName.Substring(rootDirectoryLength));
                 }
@@ -75,7 +76,8 @@ namespace RePKG.Command
 
         private static void InfoFile(FileInfo file)
         {
-            if (file.Extension.Equals(".pkg", StringComparison.OrdinalIgnoreCase))
+            if (file.Extension.Equals(".pkg", StringComparison.OrdinalIgnoreCase) ||
+                file.Extension.Equals(".mpkg", StringComparison.OrdinalIgnoreCase))
                 InfoPkg(file, Path.GetFullPath(file.Name));
             else if (file.Extension.Equals(".tex", StringComparison.OrdinalIgnoreCase))
                 InfoTex(file);

--- a/RePKG/Command/Pack.cs
+++ b/RePKG/Command/Pack.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using CommandLine;
+using RePKG.Application.Package;
+using RePKG.Application.Texture;
+using RePKG.Application.Texture.Helpers;
+using RePKG.Core.Package;
+using RePKG.Core.Package.Interfaces;
+using RePKG.Core.Texture;
+
+namespace RePKG.Command
+{
+    public static class Pack
+    {
+        private static readonly IPackageWriter _packageWriter;
+
+        static Pack()
+        {
+            _packageWriter = new PackageWriter();
+        }
+
+        public static void Action(PackOptions options)
+        {
+            var fileInfo = new FileInfo(options.Input);
+            var dirInfo = new DirectoryInfo(options.Input);
+
+            if (fileInfo.Exists)
+            {
+                PackTexFile(options, fileInfo);
+            }
+            else if (dirInfo.Exists)
+            {
+                PackDirectory(options, dirInfo);
+            }
+            else
+            {
+                Console.WriteLine("Input not found");
+                Console.WriteLine(options.Input);
+            }
+        }
+
+        private static void PackTexFile(PackOptions options, FileInfo fileInfo)
+        {
+            var outputPath = options.Output;
+            if (string.IsNullOrEmpty(outputPath))
+                outputPath = Path.ChangeExtension(fileInfo.FullName, ".tex");
+
+            var format = TexFormat.RGBA8888;
+            if (!string.IsNullOrEmpty(options.Format))
+            {
+                switch (options.Format.ToUpperInvariant())
+                {
+                    case "RGBA8888": format = TexFormat.RGBA8888; break;
+                    case "R8": format = TexFormat.R8; break;
+                    case "RG88": format = TexFormat.RG88; break;
+                    default:
+                        Console.WriteLine($"Unsupported format: {options.Format}. Supported: RGBA8888, R8, RG88");
+                        return;
+                }
+            }
+
+            var isVideo = ImageToTexConverter.IsVideoFile(fileInfo.FullName);
+            var isGif = fileInfo.Extension.Equals(".gif", StringComparison.OrdinalIgnoreCase)
+                && !isVideo && !options.NoGif;
+
+            Console.WriteLine($"Converting {fileInfo.FullName} -> {outputPath}");
+
+            Tex tex;
+            if (isVideo)
+            {
+                Console.WriteLine("Video mode: MP4 embedded as video texture");
+                tex = ImageToTexConverter.ConvertFromVideo(
+                    fileInfo.FullName, options.VideoWidth, options.VideoHeight, options.Lz4);
+            }
+            else if (isGif)
+            {
+                Console.WriteLine("GIF mode: each frame packed as separate image");
+                tex = ImageToTexConverter.ConvertFromGif(fileInfo.FullName, options.Lz4);
+            }
+            else
+            {
+                tex = ImageToTexConverter.Convert(fileInfo.FullName, format, options.Lz4);
+                Console.WriteLine($"Format: {format}, LZ4: {options.Lz4}");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputPath)));
+
+            using (var writer = new BinaryWriter(File.Open(outputPath, FileMode.Create, FileAccess.Write)))
+            {
+                var texWriter = TexWriter.Default;
+                texWriter.WriteTo(writer, tex);
+            }
+
+            Console.WriteLine("Done");
+        }
+
+        private static void PackDirectory(PackOptions options, DirectoryInfo inputInfo)
+        {
+            var outputPath = options.Output;
+            if (string.IsNullOrEmpty(outputPath))
+                outputPath = Path.Combine(Directory.GetCurrentDirectory(),
+                    options.Mpkg ? "output.mpkg" : "output.pkg");
+
+            var files = inputInfo.EnumerateFiles("*", SearchOption.AllDirectories);
+
+            // Auto-detect magic: .mpkg -> PKGM0019 (Android), .pkg -> PKGV0005 (desktop)
+            var magic = options.Magic;
+            if (string.IsNullOrEmpty(magic))
+            {
+                if (options.Mpkg || (outputPath.EndsWith(".mpkg", StringComparison.OrdinalIgnoreCase)))
+                    magic = "PKGM0019";
+                else
+                    magic = "PKGV0005";
+            }
+
+            var package = new Package { Magic = magic };
+
+            var basePath = inputInfo.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            foreach (var file in files)
+            {
+                var relativePath = file.FullName.Substring(basePath.Length + 1);
+                var bytes = File.ReadAllBytes(file.FullName);
+
+                package.Entries.Add(new PackageEntry
+                {
+                    FullPath = relativePath,
+                    Bytes = bytes,
+                    Type = PackageEntryTypeGetter.GetFromFileName(relativePath)
+                });
+            }
+
+            if (package.Entries.Count == 0)
+            {
+                Console.WriteLine("No files found in input directory");
+                return;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(outputPath)));
+
+            using (var writer = new BinaryWriter(File.Open(outputPath, FileMode.Create, FileAccess.Write)))
+            {
+                _packageWriter.WriteTo(writer, package);
+            }
+
+            Console.WriteLine($"Package created: {outputPath}");
+            Console.WriteLine($"Entries: {package.Entries.Count}");
+            Console.WriteLine($"Magic: {package.Magic}");
+        }
+    }
+
+    [Verb("pack", HelpText = "Pack file to .tex or directory to PKG/MPKG.")]
+    public class PackOptions
+    {
+        [Option('o', "output", Required = false, HelpText = "Output path (.tex for file, .pkg/.mpkg for directory)")]
+        public string Output { get; set; }
+
+        [Option('m', "magic", Required = false, HelpText = "Magic string for PKG header: PKGV0005 (desktop, default for .pkg) or PKGM0019 (Android, default for .mpkg)")]
+        public string Magic { get; set; }
+
+        [Option("mpkg", Required = false, HelpText = "Create .mpkg package with PKGM0019 magic (Android Wallpaper Engine)")]
+        public bool Mpkg { get; set; }
+
+        [Option('f', "format", Required = false, HelpText = "Tex format: RGBA8888, R8, RG88 (file mode only)")]
+        public string Format { get; set; }
+
+        [Option("lz4", Required = false, HelpText = "Apply LZ4 compression (file mode only)")]
+        public bool Lz4 { get; set; }
+
+        [Option("no-gif", Required = false, HelpText = "Treat GIF as single frame (file mode only)")]
+        public bool NoGif { get; set; }
+
+        [Option("video-width", Required = false, HelpText = "Video width in pixels (auto-detected via ffprobe if omitted)")]
+        public int VideoWidth { get; set; }
+
+        [Option("video-height", Required = false, HelpText = "Video height in pixels (auto-detected via ffprobe if omitted)")]
+        public int VideoHeight { get; set; }
+
+        [Value(0, Required = true, HelpText = "Input file or directory path", MetaName = "Input")]
+        public string Input { get; set; }
+    }
+}

--- a/RePKG/Program.cs
+++ b/RePKG/Program.cs
@@ -18,9 +18,10 @@ namespace RePKG
                 return;
             }
 
-            Parser.Default.ParseArguments<ExtractOptions, InfoOptions>(args)
+            Parser.Default.ParseArguments<ExtractOptions, InfoOptions, PackOptions>(args)
                 .WithParsed<ExtractOptions>(Extract.Action)
-                .WithParsed<InfoOptions>(Info.Action);
+                .WithParsed<InfoOptions>(Info.Action)
+                .WithParsed<PackOptions>(Pack.Action);
         }
 
         private static void Cancel(object sender, ConsoleCancelEventArgs e)
@@ -41,9 +42,10 @@ namespace RePKG
             {
                 var interactiveArgs = line.SplitArguments();
 
-                Parser.Default.ParseArguments<ExtractOptions, InfoOptions>(interactiveArgs)
+                Parser.Default.ParseArguments<ExtractOptions, InfoOptions, PackOptions>(interactiveArgs)
                     .WithParsed<ExtractOptions>(Extract.Action)
-                    .WithParsed<InfoOptions>(Info.Action);
+                    .WithParsed<InfoOptions>(Info.Action)
+                    .WithParsed<PackOptions>(Pack.Action);
             }
         }
     }

--- a/RePKG/RePKG.csproj
+++ b/RePKG/RePKG.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <RootNamespace>RePKG</RootNamespace>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFrameworks>net472;net8.0</TargetFrameworks>
         <Version>0.4.0</Version>
         <Copyright>Copyright © NotScuffed 2025</Copyright>
     </PropertyGroup>
@@ -16,8 +16,8 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
     </ItemGroup>
     
-    <ItemGroup>
-      <Reference Include="Microsoft.CSharp" />
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="Microsoft.CSharp" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

This PR adds a `pack` command for creating `.pkg`/`.mpkg` packages and `.tex` textures from images, GIFs, and video files. It also adds `.mpkg` extension support to existing commands (`info`, `extract`) and fixes a Unicode path bug in the PKG writer.

## Commits

### 1. fix: use UTF-8 byte count in WriteStringI32Size
`WriteStringI32Size` used `input.Length` (character count) instead of UTF-8 `bytes.Length`. Non-ASCII filenames (e.g., Chinese) had incorrect length prefix, corrupting PKG headers.

### 2. build: add net8.0 target framework
Dual-target `net472;net8.0` for cross-platform compatibility. Conditional `Microsoft.CSharp` reference.

### 3. fix: improve TexToImageConverter crop/resize logic
Handle case where mipmap dimensions are smaller than header dimensions by resizing.

### 4. fix: support .mpkg extension in info and extract commands
- Recognize `.mpkg` files in single-file mode (was only `.pkg`)
- Merge duplicate `.pkg`/`.mpkg` directory enumeration into single `Concat` calls

### 5. feat: add pack command and video TEX support
**New `pack` command:**
- `repkg pack <dir>` — pack directory to `.pkg`/`.mpkg` with auto-magic detection
- `repkg pack <file>` — convert image (PNG/JPG/GIF) or video (MP4/WebM) to `.tex`
- `--mpkg` flag / `.mpkg` output extension → auto `PKGM0019` magic (Android)
- `.pkg` output → auto `PKGV0005` magic (desktop)
- Options: `--format`, `--lz4`, `--no-gif`, `--video-width/height`, `-m` magic override

**New ImageToTexConverter:**
- PNG/JPG → RGBA8888/R8/RG88 TEX textures
- GIF → multi-frame TEX with `TEXS0003` frame info
- Video → V4 video texture TEX (MP4 wrapped, FIF_UNKNOWN + isVideoMp4=0 + V3 mipmap fallback)

**V4 container writer:**
- TEXB0004 container header with Format + isVideoMp4 flag
- WriteMipmapV4 with extra metadata fields (param1, param2, conditionJson, param3)
- Non-MP4 V4 containers fall back to V3 mipmap format